### PR TITLE
fix(overflow): Fixed issue with scrollbar appearing due to using 100v…

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -32,7 +32,7 @@ body {
 
 nav {
   height: 80px;
-  width: 100vw;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-around;


### PR DESCRIPTION
…w instead of %

## Changes
_List Changes Introduced by this PR_
1. Overflow fixed due to using vw

## Purpose
No unneccesory scroll bar added

## Approach
Now there is no scroll bar for left/right

## Learning
[link](https://stackoverflow.com/questions/31039979/css-units-what-is-the-difference-between-vh-vw-and)

_If this closes an issue, reference the issue here. If it doesn't, remove this line_
Closes #000
